### PR TITLE
Feature: add basic project structure and InterviewerProfile model

### DIFF
--- a/app/api/profiles.py
+++ b/app/api/profiles.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+from models.profile import InterviewerProfile
+from data.mock_data import nerd_interviewer
+router = APIRouter()
+
+@router.get("/profiles/1")
+def get_profile():
+    return nerd_interviewer

--- a/app/data/mock_data.py
+++ b/app/data/mock_data.py
@@ -1,0 +1,40 @@
+from models.profile import InterviewerProfile
+
+typical_phrases = [
+"А какая временная сложность у quicksort в худшем случае?",
+"Расскажите разницу между TCP и UDP протоколами",
+"Что происходит при выполнении команды git merge --no-ff?",
+"Объясните принцип работы garbage collector в Python",
+"А почему вы не использовали паттерн Singleton в этом случае?"
+]
+
+advice_tips = [
+"Переводите всё в практические примеры - 'Это как пицца...'",
+"Начинайте с фразы 'В реальных проектах обычно...'",
+"Признайтесь честно: 'Хороший вопрос, а как вы это решаете?'"
+]
+
+revenge_tactics = [
+"Спросите его про soft skills и эмоциональный интеллект",
+"Попросите объяснить код без технических терминов",
+"Задайте вопрос: 'А как это поможет бизнесу?'"
+]
+
+avatar_url = "https://a.d-cd.net/9aec42as-960.jpg"
+
+nerd_interviewer = InterviewerProfile(
+    name = "fred",
+    archetype = "душнила",
+    description = "классический душнила, постоянно душит своими ненужными советами",
+    typical_phrases = typical_phrases,
+    advice_tips = advice_tips,
+    avatar_url = avatar_url,
+    revenge_tactics = revenge_tactics
+)
+
+if __name__ == "__main__":
+    print("Тестируем модель...")
+    print(f"Имя: {nerd_interviewer.name}")
+    print(f"Тип: {nerd_interviewer.archetype}")
+    print(f"Количество фраз: {len(nerd_interviewer.typical_phrases)}")
+    print("Первая фраза:", nerd_interviewer.typical_phrases[0])

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
+from api import profiles
 
 app = FastAPI()
 
 @app.get("/")
 async def root():
     return {"message": "Hello World"}
+
+app.include_router(profiles.router)

--- a/app/models/profile.py
+++ b/app/models/profile.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import List
+
+class InterviewerProfile(BaseModel):
+    name: str
+    archetype: str
+    description: str
+    typical_phrases: List[str]
+    advice_tips: List[str]
+    avatar_url: str
+    revenge_tactics: List[str]


### PR DESCRIPTION
## What was done
- Created Pydantic model `InterviewerProfile` with validation
- Added mock data for first interviewer (nerd archetype)
- Implemented `GET /profiles/1` endpoint
- Set up proper project structure: `models/`, `data/`, `api/`

## Testing
- [x] Pydantic model validation works
- [x] API endpoint returns correct JSON
- [x] Manual testing via browser successful

## Next steps
- Add more interviewer types
- Implement list endpoint `/profiles/`
- Add random phrase/advice endpoints